### PR TITLE
🪲 [Fix]: Fix linter settings and docs

### DIFF
--- a/.github/PSModule.yml
+++ b/.github/PSModule.yml
@@ -19,3 +19,12 @@ Test:
 # Build:
 #   Docs:
 #     Skip: true
+Linter:
+  env:
+    VALIDATE_BIOME_FORMAT: false
+    VALIDATE_BIOME_LINT: false
+    VALIDATE_GITHUB_ACTIONS_ZIZMOR: false
+    VALIDATE_JSCPD: false
+    VALIDATE_JSON_PRETTIER: false
+    VALIDATE_MARKDOWN_PRETTIER: false
+    VALIDATE_YAML_PRETTIER: false

--- a/.github/PSModule.yml
+++ b/.github/PSModule.yml
@@ -19,3 +19,13 @@ Test:
 # Build:
 #   Docs:
 #     Skip: true
+
+Linter:
+  env:
+    VALIDATE_BIOME_FORMAT: false
+    VALIDATE_BIOME_LINT: false
+    VALIDATE_GITHUB_ACTIONS_ZIZMOR: false
+    VALIDATE_JSCPD: false
+    VALIDATE_JSON_PRETTIER: false
+    VALIDATE_MARKDOWN_PRETTIER: false
+    VALIDATE_YAML_PRETTIER: false

--- a/.github/linters/.markdown-lint.yml
+++ b/.github/linters/.markdown-lint.yml
@@ -8,18 +8,19 @@
 ###############
 # Rules by id #
 ###############
-MD004: false                  # Unordered list style
+MD004: false # Unordered list style
 MD007:
-  indent: 2                   # Unordered list indentation
+  indent: 2 # Unordered list indentation
 MD013:
-  line_length: 808            # Line length
+  line_length: 808 # Line length
+MD024: false # no-duplicate-heading, INPUTS and OUTPUTS _can_ be the same item
 MD026:
-  punctuation: ".,;:!。，；:"  # List of not allowed
-MD029: false                  # Ordered list item prefix
-MD033: false                  # Allow inline HTML
-MD036: false                  # Emphasis used instead of a heading
+  punctuation: '.,;:!。，；:' # List of not allowed
+MD029: false # Ordered list item prefix
+MD033: false # Allow inline HTML
+MD036: false # Emphasis used instead of a heading
 
 #################
 # Rules by tags #
 #################
-blank_lines: false  # Error on blank lines
+blank_lines: false # Error on blank lines

--- a/src/functions/public/Get-PSModuleTest.ps1
+++ b/src/functions/public/Get-PSModuleTest.ps1
@@ -5,6 +5,9 @@ function Get-PSModuleTest {
         .SYNOPSIS
         Performs tests on a module.
 
+        .DESCRIPTION
+        Performs tests on a module.
+
         .EXAMPLE
         Test-PSModule -Name 'World'
 


### PR DESCRIPTION
This pull request makes a few minor configuration and documentation updates, primarily focused on linter and testing behavior.

- **Linter Configuration Updates:**
  - Disabled several linter validations in the `Linter` environment section of `.github/PSModule.yml`, such as Biome format/lint, GitHub Actions Zizmor, JSCPD, and various Prettier checks.
  - Updated `.github/linters/.markdown-lint.yml` to disable duplicate heading checks (`MD024`) and made a minor formatting change to the punctuation list for `MD026`.

- **Documentation Improvement:**
  - Added a `.DESCRIPTION` section to the `Get-PSModuleTest` function in `src/functions/public/Get-PSModuleTest.ps1` to improve help output.